### PR TITLE
Ensure the #fb-root before loading script

### DIFF
--- a/sdk.js
+++ b/sdk.js
@@ -1,7 +1,10 @@
-(function(d, s, id){
-   var js, fjs = d.getElementsByTagName(s)[0];
-   if (d.getElementById(id)) {return;}
-   js = d.createElement(s); js.id = id;
-   js.src = "//connect.facebook.net/en_US/sdk.js";
-   fjs.parentNode.insertBefore(js, fjs);
-}(document, 'script', 'facebook-jssdk'));
+Meteor.startup(function () {
+   $('body').prepend('<div id="fb-root"></div>');
+   (function(d, s, id){
+      var js, fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) {return;}
+      js = d.createElement(s); js.id = id;
+      js.src = "//connect.facebook.net/en_US/sdk.js";
+      fjs.parentNode.insertBefore(js, fjs);
+   }(document, 'script', 'facebook-jssdk'));
+});


### PR DESCRIPTION
Make sure that #fb-root exists in the page to avoid sdk errors saying: "Uncaught Error: init not called with valid version "

The issue is mentioned: http://stackoverflow.com/questions/24019877/fb-init-function-gives-wrong-version-error (and personally experienced it)

Meteor.startup has to be waited upon, because the document does not come with a body element, so you cannot initialize the fb-root before meteor does its magic
